### PR TITLE
Capslock-on fix and adding some more hungarian layout specific symbols

### DIFF
--- a/Hungarian_Win.keylayout
+++ b/Hungarian_Win.keylayout
@@ -1,1 +1,1062 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd"><!--Last edited by Ukelele version 2.0.1 on 2010-09-23 at 18:59 (GMT+09:00)--><!----><keyboard group="29" id="30763" name="HungarianWin" maxout="1">    <layouts>        <layout first="0" last="0" modifiers="30" mapSet="138"/>    </layouts>    <modifierMap id="30" defaultIndex="0">        <keyMapSelect mapIndex="0">            <modifier keys="command?"/>            <modifier keys="anyShift caps? command"/>        </keyMapSelect>        <keyMapSelect mapIndex="1">            <modifier keys="anyShift caps?"/>        </keyMapSelect>        <keyMapSelect mapIndex="2">            <modifier keys="caps command?"/>        </keyMapSelect>        <keyMapSelect mapIndex="3">            <modifier keys="anyOption"/>        </keyMapSelect>        <keyMapSelect mapIndex="4">            <modifier keys="anyShift caps? anyOption command?"/>        </keyMapSelect>        <keyMapSelect mapIndex="5">            <modifier keys="caps anyOption command?"/>        </keyMapSelect>        <keyMapSelect mapIndex="6">            <modifier keys="anyOption command"/>        </keyMapSelect>        <keyMapSelect mapIndex="7">            <modifier keys="anyShift? caps? anyOption? anyControl"/>            <modifier keys="anyShift? anyOption? command? anyControl"/>            <modifier keys="anyShift caps anyOption command rightControl"/>            <modifier keys="anyShift caps rightOption? command anyControl"/>            <modifier keys="rightShift? caps anyOption command anyControl"/>            <modifier keys="anyShift caps anyOption command control"/>            <modifier keys="anyShift caps option? command anyControl"/>            <modifier keys="shift? caps anyOption command anyControl"/>            <modifier keys="caps? anyOption? command? anyControl"/>        </keyMapSelect>    </modifierMap>    <keyMapSet id="138">        <keyMap index="0">            <key code="0" action="9"/>            <key code="1" action="23"/>            <key code="2" output="d"/>            <key code="3" output="f"/>            <key code="4" output="h"/>            <key code="5" output="g"/>            <key code="6" output="y"/>            <key code="7" output="x"/>            <key code="8" action="15"/>            <key code="9" output="v"/>            <key code="10" output="0"/>            <key code="11" output="b"/>            <key code="12" output="q"/>            <key code="13" output="w"/>            <key code="14" action="17"/>            <key code="15" action="21"/>            <key code="16" action="26"/>            <key code="17" output="t"/>            <key code="18" output="1"/>            <key code="19" output="2"/>            <key code="20" output="3"/>            <key code="21" output="4"/>            <key code="22" output="6"/>            <key code="23" output="5"/>            <key code="24" output="ó"/>            <key code="25" output="9"/>            <key code="26" output="7"/>            <key code="27" output="ü"/>            <key code="28" output="8"/>            <key code="29" output="ö"/>            <key code="30" output="ú"/>            <key code="31" action="10"/>            <key code="32" action="11"/>            <key code="33" output="ő"/>            <key code="34" output="i"/>            <key code="35" output="p"/>            <key code="36" output="&#x000D;"/>            <key code="37" action="13"/>            <key code="38" output="j"/>            <key code="39" output="á"/>            <key code="40" output="k"/>            <key code="41" output="é"/>            <key code="42" output="ű"/>            <key code="43" output=","/>            <key code="44" output="-"/>            <key code="45" action="19"/>            <key code="46" output="m"/>            <key code="47" output="."/>            <key code="48" output="&#x0009;"/>            <key code="49" action="5"/>            <key code="50" output="0"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="&#x001D;"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="&#x001C;"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="&#x001F;"/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="&#x001E;"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="1">            <key code="0" action="6"/>            <key code="1" action="22"/>            <key code="2" output="D"/>            <key code="3" output="F"/>            <key code="4" output="H"/>            <key code="5" output="G"/>            <key code="6" output="Y"/>            <key code="7" output="X"/>            <key code="8" action="14"/>            <key code="9" output="V"/>            <key code="10" output="§"/>            <key code="11" output="B"/>            <key code="12" output="Q"/>            <key code="13" output="W"/>            <key code="14" action="16"/>            <key code="15" action="20"/>            <key code="16" action="25"/>            <key code="17" action="24"/>            <key code="18" output="&#x0027;"/>            <key code="19" output="&#x0022;"/>            <key code="20" output="+"/>            <key code="21" output="!"/>            <key code="22" output="/"/>            <key code="23" output="%"/>            <key code="24" output="Ó"/>            <key code="25" output=")"/>            <key code="26" output="="/>            <key code="27" output="Ü"/>            <key code="28" output="("/>            <key code="29" output="Ö"/>            <key code="30" output="Ú"/>            <key code="31" action="7"/>            <key code="32" action="8"/>            <key code="33" output="Ő"/>            <key code="34" output="I"/>            <key code="35" output="P"/>            <key code="36" output="&#x000D;"/>            <key code="37" action="12"/>            <key code="38" output="J"/>            <key code="39" output="Á"/>            <key code="40" output="K"/>            <key code="41" output="É"/>            <key code="42" output="Ű"/>            <key code="43" output="?"/>            <key code="44" output="_"/>            <key code="45" action="18"/>            <key code="46" output="M"/>            <key code="47" output=":"/>            <key code="48" output="&#x0009;"/>            <key code="49" action="5"/>            <key code="50" output="Í"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="*"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="+"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="="/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="/"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="2">            <key code="0" action="6"/>            <key code="1" action="22"/>            <key code="2" output="D"/>            <key code="3" output="F"/>            <key code="4" output="H"/>            <key code="5" output="G"/>            <key code="6" output="Y"/>            <key code="7" output="X"/>            <key code="8" action="14"/>            <key code="9" output="V"/>            <key code="10" output="0"/>            <key code="11" output="B"/>            <key code="12" output="Q"/>            <key code="13" output="W"/>            <key code="14" action="16"/>            <key code="15" action="20"/>            <key code="16" action="25"/>            <key code="17" action="24"/>            <key code="18" output="1"/>            <key code="19" output="2"/>            <key code="20" output="3"/>            <key code="21" output="4"/>            <key code="22" output="6"/>            <key code="23" output="5"/>            <key code="24" output="Ó"/>            <key code="25" output="9"/>            <key code="26" output="7"/>            <key code="27" output="Ü"/>            <key code="28" output="8"/>            <key code="29" output="Ö"/>            <key code="30" output="Ú"/>            <key code="31" action="7"/>            <key code="32" action="8"/>            <key code="33" output="Ő"/>            <key code="34" output="I"/>            <key code="35" output="P"/>            <key code="36" output="&#x000D;"/>            <key code="37" action="12"/>            <key code="38" output="J"/>            <key code="39" output="Á"/>            <key code="40" output="K"/>            <key code="41" output="É"/>            <key code="42" output="Ű"/>            <key code="43" output=","/>            <key code="44" output="-"/>            <key code="45" action="18"/>            <key code="46" output="M"/>            <key code="47" output="."/>            <key code="48" output="&#x0009;"/>            <key code="49" action="5"/>            <key code="50" output="0"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="&#x001D;"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="&#x001C;"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="&#x001F;"/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="&#x001E;"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="3">            <key code="0" output="ą"/>            <key code="1" output="ß"/>            <key code="2" output="∂"/>            <key code="3" output="["/>            <key code="4" output="ķ"/>            <key code="5" output="]"/>            <key code="6" output="«"/>            <key code="7" output="#"/>            <key code="8" output="&#x0026;"/>            <key code="9" output="@"/>            <key code="10" output="¬"/>            <key code="11" output="{"/>            <key code="12" output="\"/>            <key code="13" output="|"/>            <key code="14" output="€"/>            <key code="15" output="¶"/>            <key code="16" output="ź"/>            <key code="17" output="†"/>            <key code="18" output="~"/>            <key code="19" output="™"/>            <key code="20" output="^"/>            <key code="21" output="$"/>            <key code="22" output="›"/>            <key code="23" output="‹"/>            <key code="24" output="≠"/>            <key code="25" output="]"/>            <key code="26" output="`"/>            <key code="27" output="\"/>            <key code="28" output="["/>            <key code="29" output="}"/>            <key code="30" output="~"/>            <key code="31" output="Ņ"/>            <key code="32" action="0"/>            <key code="33" output="¨"/>            <key code="34" action="1"/>            <key code="35" output="Ļ"/>            <key code="36" output="&#x000D;"/>            <key code="37" output="•"/>            <key code="38" output="í"/>            <key code="39" output="^"/>            <key code="40" output="Ż"/>            <key code="41" output="$"/>            <key code="42" output="`"/>            <key code="43" output=";"/>            <key code="44" output="*"/>            <key code="45" output="}"/>            <key code="46" output="&#x003C;"/>            <key code="47" output="&#x003E;"/>            <key code="48" output="&#x0009;"/>            <key code="49" output=" "/>            <key code="50" output="|"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="&#x001D;"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="&#x001C;"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="&#x001F;"/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="&#x001E;"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="4">            <key code="0" output="Ą"/>            <key code="1" output="ż"/>            <key code="2" output="Ž"/>            <key code="3" output="ž"/>            <key code="4" output="Õ"/>            <key code="5" output="Ū"/>            <key code="6" output="&#x003C;"/>            <key code="7" output="&#x003E;"/>            <key code="8" output="©"/>            <key code="9" output="‚"/>            <key code="10" output="•"/>            <key code="11" output="’"/>            <key code="12" output="ļ"/>            <key code="13" output="Ł"/>            <key code="14" output="š"/>            <key code="15" output="®"/>            <key code="16" output="Ź"/>            <key code="17" output="ś"/>            <key code="18" output="ŕ"/>            <key code="19" output="Ř"/>            <key code="20" output="#"/>            <key code="21" output="$"/>            <key code="22" output="Ŗ"/>            <key code="23" output="ř"/>            <key code="24" output="Ī"/>            <key code="25" output="}"/>            <key code="26" output="ŗ"/>            <key code="27" output="ī"/>            <key code="28" output="™"/>            <key code="29" output="°"/>            <key code="30" output="ý"/>            <key code="31" output="Į"/>            <key code="32" output="†"/>            <key code="33" output="Ý"/>            <key code="34" output="ť"/>            <key code="35" output="ł"/>            <key code="36" output="&#x000D;"/>            <key code="37" output="Ů"/>            <key code="38" output="Í"/>            <key code="39" action="4"/>            <key code="40" output="&#x0026;"/>            <key code="41" output="ō"/>            <key code="42" output="Ģ"/>            <key code="43" output="*"/>            <key code="44" output="—"/>            <key code="45" output="Ų"/>            <key code="46" output="ų"/>            <key code="47" output="÷"/>            <key code="48" output="&#x0009;"/>            <key code="49" output=" "/>            <key code="50" output="Ŕ"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="*"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="+"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="="/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="/"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="5">            <key code="0" output="Ā"/>            <key code="1" output="ĺ"/>            <key code="2" output="Č"/>            <key code="3" output="č"/>            <key code="4" output="ď"/>            <key code="5" output="Ď"/>            <key code="6" output="ů"/>            <key code="7" output="Ű"/>            <key code="8" output="ā"/>            <key code="9" output="◊"/>            <key code="10" output="0"/>            <key code="11" output="ű"/>            <key code="12" output="ő"/>            <key code="13" output="Š"/>            <key code="14" output="š"/>            <key code="15" output="Ś"/>            <key code="16" output="ņ"/>            <key code="17" output="ś"/>            <key code="18" output="Ń"/>            <key code="19" output="ň"/>            <key code="20" output="£"/>            <key code="21" output="Ę"/>            <key code="22" output="Ė"/>            <key code="23" output="į"/>            <key code="24" output="ě"/>            <key code="25" output="Ľ"/>            <key code="26" output="ė"/>            <key code="27" output="Ě"/>            <key code="28" output="•"/>            <key code="29" output="ľ"/>            <key code="30" output="‘"/>            <key code="31" output="ô"/>            <key code="32" output="Ť"/>            <key code="33" output="“"/>            <key code="34" output="ť"/>            <key code="35" output="õ"/>            <key code="36" output="&#x000D;"/>            <key code="37" output="ē"/>            <key code="38" output="Ē"/>            <key code="39" output="Ä"/>            <key code="40" output="ū"/>            <key code="41" output="ä"/>            <key code="42" output="ģ"/>            <key code="43" output="≤"/>            <key code="44" output="÷"/>            <key code="45" output="Ų"/>            <key code="46" output="ų"/>            <key code="47" output="≥"/>            <key code="48" output="&#x0009;"/>            <key code="49" output=" "/>            <key code="50" output="`"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="&#x001D;"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="&#x001C;"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="&#x001F;"/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="&#x001E;"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="6">            <key code="0" output="Ć"/>            <key code="1" output="ß"/>            <key code="2" output="∂"/>            <key code="3" output="ń"/>            <key code="4" output="ķ"/>            <key code="5" output="©"/>            <key code="6" output="Ĺ"/>            <key code="7" output="Ň"/>            <key code="8" output="ć"/>            <key code="9" output="√"/>            <key code="10" output="*"/>            <key code="11" output="ļ"/>            <key code="12" output="Ō"/>            <key code="13" output="∑"/>            <key code="14" output="ę"/>            <key code="15" output="®"/>            <key code="16" output="ī"/>            <key code="17" output="†"/>            <key code="18" output="Ń"/>            <key code="19" output="™"/>            <key code="20" output="£"/>            <key code="21" output="$"/>            <key code="22" output="§"/>            <key code="23" output="į"/>            <key code="24" output="≠"/>            <key code="25" output="Ľ"/>            <key code="26" output="¶"/>            <key code="27" output="–"/>            <key code="28" output="•"/>            <key code="29" output="ľ"/>            <key code="30" output="‘"/>            <key code="31" output="Ņ"/>            <key code="32" output="¨"/>            <key code="33" output="“"/>            <key code="34" output="^"/>            <key code="35" output="Ļ"/>            <key code="36" output="&#x000D;"/>            <key code="37" output="¬"/>            <key code="38" output="∆"/>            <key code="39" output="Ä"/>            <key code="40" output="Ż"/>            <key code="41" output="ä"/>            <key code="42" output="«"/>            <key code="43" output=";"/>            <key code="44" output="–"/>            <key code="45" output="~"/>            <key code="46" output=";"/>            <key code="47" output="≥"/>            <key code="48" output="&#x0009;"/>            <key code="49" output=" "/>            <key code="50" output="`"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output=","/>            <key code="66" output="&#x001D;"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="&#x001C;"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="&#x001F;"/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="&#x001E;"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>        <keyMap index="7">            <key code="0" output="&#x0001;"/>            <key code="1" output="&#x0013;"/>            <key code="2" output="&#x0004;"/>            <key code="3" output="&#x0006;"/>            <key code="4" output="&#x0008;"/>            <key code="5" output="&#x0007;"/>            <key code="6" output="&#x001A;"/>            <key code="7" output="&#x0018;"/>            <key code="8" output="&#x0003;"/>            <key code="9" output="&#x0016;"/>            <key code="10" output="0"/>            <key code="11" output="&#x0002;"/>            <key code="12" output="&#x0011;"/>            <key code="13" output="&#x0017;"/>            <key code="14" output="&#x0005;"/>            <key code="15" output="&#x0012;"/>            <key code="16" output="&#x0019;"/>            <key code="17" output="&#x0014;"/>            <key code="18" output="1"/>            <key code="19" output="2"/>            <key code="20" output="3"/>            <key code="21" output="4"/>            <key code="22" output="6"/>            <key code="23" output="5"/>            <key code="24" output="="/>            <key code="25" output="9"/>            <key code="26" output="7"/>            <key code="27" output="&#x001F;"/>            <key code="28" output="8"/>            <key code="29" output="0"/>            <key code="30" output="&#x001D;"/>            <key code="31" output="&#x000F;"/>            <key code="32" output="&#x0015;"/>            <key code="33" output="&#x001B;"/>            <key code="34" output="&#x0009;"/>            <key code="35" output="&#x0010;"/>            <key code="36" output="&#x000D;"/>            <key code="37" output="&#x000C;"/>            <key code="38" output="&#x000A;"/>            <key code="39" output="&#x0027;"/>            <key code="40" output="&#x000B;"/>            <key code="41" output=";"/>            <key code="42" output="&#x001C;"/>            <key code="43" output=","/>            <key code="44" output="/"/>            <key code="45" output="&#x000E;"/>            <key code="46" output="&#x000D;"/>            <key code="47" output="."/>            <key code="48" output="&#x0009;"/>            <key code="49" action="5"/>            <key code="50" output="`"/>            <key code="51" output="&#x0008;"/>            <key code="52" output="&#x0003;"/>            <key code="53" output="&#x001B;"/>            <key code="64" output="&#x0010;"/>            <key code="65" output="."/>            <key code="66" output="&#x001D;"/>            <key code="67" output="*"/>            <key code="69" output="+"/>            <key code="70" output="&#x001C;"/>            <key code="71" output="&#x001B;"/>            <key code="72" output="&#x001F;"/>            <key code="75" output="/"/>            <key code="76" output="&#x0003;"/>            <key code="77" output="&#x001E;"/>            <key code="78" output="-"/>            <key code="79" output="&#x0010;"/>            <key code="80" output="&#x0010;"/>            <key code="81" output="="/>            <key code="82" output="0"/>            <key code="83" output="1"/>            <key code="84" output="2"/>            <key code="85" output="3"/>            <key code="86" output="4"/>            <key code="87" output="5"/>            <key code="88" output="6"/>            <key code="89" output="7"/>            <key code="91" output="8"/>            <key code="92" output="9"/>            <key code="96" output="&#x0010;"/>            <key code="97" output="&#x0010;"/>            <key code="98" output="&#x0010;"/>            <key code="99" output="&#x0010;"/>            <key code="100" output="&#x0010;"/>            <key code="101" output="&#x0010;"/>            <key code="102" output="&#x0010;"/>            <key code="103" output="&#x0010;"/>            <key code="104" output="&#x0010;"/>            <key code="105" output="&#x0010;"/>            <key code="106" output="&#x0010;"/>            <key code="107" output="&#x0010;"/>            <key code="108" output="&#x0010;"/>            <key code="109" output="&#x0010;"/>            <key code="110" output="&#x0010;"/>            <key code="111" output="&#x0010;"/>            <key code="112" output="&#x0010;"/>            <key code="113" output="&#x0010;"/>            <key code="114" output="&#x0005;"/>            <key code="115" output="&#x0001;"/>            <key code="116" output="&#x000B;"/>            <key code="117" output="&#x007F;"/>            <key code="118" output="&#x0010;"/>            <key code="119" output="&#x0004;"/>            <key code="120" output="&#x0010;"/>            <key code="121" output="&#x000C;"/>            <key code="122" output="&#x0010;"/>            <key code="123" output="&#x001C;"/>            <key code="124" output="&#x001D;"/>            <key code="125" output="&#x001F;"/>            <key code="126" output="&#x001E;"/>        </keyMap>    </keyMapSet>    <actions>        <action id="0">            <when state="none" next="s1"/>        </action>        <action id="1">            <when state="none" next="s2"/>        </action>        <action id="2">            <when state="none" next="s3"/>        </action>        <action id="3">            <when state="none" next="s4"/>        </action>        <action id="4">            <when state="none" next="s5"/>        </action>        <action id="5">            <when state="none" output=" "/>            <when state="s1" output="¨"/>            <when state="s2" output="^"/>            <when state="s3" output="–"/>            <when state="s4" output="~"/>            <when state="s5" output="ˇ"/>        </action>        <action id="6">            <when state="none" output="A"/>            <when state="s1" output="Ä"/>        </action>        <action id="7">            <when state="none" output="O"/>            <when state="s1" output="Ö"/>            <when state="s2" output="Ô"/>            <when state="s4" output="Õ"/>        </action>        <action id="8">            <when state="none" output="U"/>            <when state="s1" output="Ü"/>        </action>        <action id="9">            <when state="none" output="a"/>            <when state="s1" output="ä"/>        </action>        <action id="10">            <when state="none" output="o"/>            <when state="s1" output="ö"/>            <when state="s2" output="ô"/>            <when state="s4" output="õ"/>        </action>        <action id="11">            <when state="none" output="u"/>            <when state="s1" output="ü"/>        </action>        <action id="12">            <when state="none" output="L"/>            <when state="s3" output="Ł"/>        </action>        <action id="13">            <when state="none" output="l"/>            <when state="s3" output="ł"/>        </action>        <action id="14">            <when state="none" output="C"/>            <when state="s5" output="Č"/>        </action>        <action id="15">            <when state="none" output="c"/>            <when state="s5" output="č"/>        </action>        <action id="16">            <when state="none" output="E"/>            <when state="s5" output="Ě"/>        </action>        <action id="17">            <when state="none" output="e"/>            <when state="s5" output="ě"/>        </action>        <action id="18">            <when state="none" output="N"/>            <when state="s5" output="Ň"/>        </action>        <action id="19">            <when state="none" output="n"/>            <when state="s5" output="ň"/>        </action>        <action id="20">            <when state="none" output="R"/>            <when state="s5" output="Ř"/>        </action>        <action id="21">            <when state="none" output="r"/>            <when state="s5" output="ř"/>        </action>        <action id="22">            <when state="none" output="S"/>            <when state="s5" output="Š"/>        </action>        <action id="23">            <when state="none" output="s"/>            <when state="s5" output="š"/>        </action>        <action id="24">            <when state="none" output="T"/>            <when state="s5" output="Ť"/>        </action>        <action id="25">            <when state="none" output="Z"/>            <when state="s5" output="Ž"/>        </action>        <action id="26">            <when state="none" output="z"/>            <when state="s5" output="ž"/>        </action>    </actions>    <terminators>        <when state="s1" output="¨"/>        <when state="s2" output="^"/>        <when state="s3" output="–"/>        <when state="s4" output="~"/>        <when state="s5" output="ˇ"/>    </terminators></keyboard>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
+<!--Last edited by Ukelele version 2.0.1 on 2010-09-23 at 18:59 (GMT+09:00)-->
+<!---->
+<keyboard group="29" id="30763" name="HungarianWin" maxout="1">
+    <layouts>
+        <layout first="0" last="0" modifiers="30" mapSet="138"/>
+    </layouts>
+    <modifierMap id="30" defaultIndex="0">
+        <keyMapSelect mapIndex="0">
+            <modifier keys="command?"/>
+            <modifier keys="anyShift caps? command"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="1">
+            <modifier keys="anyShift caps?"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="2">
+            <modifier keys="caps command?"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="3">
+            <modifier keys="anyOption"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="4">
+            <modifier keys="anyShift caps? anyOption command?"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="5">
+            <modifier keys="caps anyOption command?"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="6">
+            <modifier keys="anyOption command"/>
+        </keyMapSelect>
+        <keyMapSelect mapIndex="7">
+            <modifier keys="anyShift? caps? anyOption? anyControl"/>
+            <modifier keys="anyShift? anyOption? command? anyControl"/>
+            <modifier keys="anyShift caps anyOption command rightControl"/>
+            <modifier keys="anyShift caps rightOption? command anyControl"/>
+            <modifier keys="rightShift? caps anyOption command anyControl"/>
+            <modifier keys="anyShift caps anyOption command control"/>
+            <modifier keys="anyShift caps option? command anyControl"/>
+            <modifier keys="shift? caps anyOption command anyControl"/>
+            <modifier keys="caps? anyOption? command? anyControl"/>
+        </keyMapSelect>
+    </modifierMap>
+    <keyMapSet id="138">
+        <keyMap index="0">
+            <key code="0" action="9"/>
+            <key code="1" action="23"/>
+            <key code="2" output="d"/>
+            <key code="3" output="f"/>
+            <key code="4" output="h"/>
+            <key code="5" output="g"/>
+            <key code="6" output="y"/>
+            <key code="7" output="x"/>
+            <key code="8" action="15"/>
+            <key code="9" output="v"/>
+            <key code="10" output="0"/>
+            <key code="11" output="b"/>
+            <key code="12" output="q"/>
+            <key code="13" output="w"/>
+            <key code="14" action="17"/>
+            <key code="15" action="21"/>
+            <key code="16" action="26"/>
+            <key code="17" output="t"/>
+            <key code="18" output="1"/>
+            <key code="19" output="2"/>
+            <key code="20" output="3"/>
+            <key code="21" output="4"/>
+            <key code="22" output="6"/>
+            <key code="23" output="5"/>
+            <key code="24" output="ó"/>
+            <key code="25" output="9"/>
+            <key code="26" output="7"/>
+            <key code="27" output="ü"/>
+            <key code="28" output="8"/>
+            <key code="29" output="ö"/>
+            <key code="30" output="ú"/>
+            <key code="31" action="10"/>
+            <key code="32" action="11"/>
+            <key code="33" output="ő"/>
+            <key code="34" output="i"/>
+            <key code="35" output="p"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" action="13"/>
+            <key code="38" output="j"/>
+            <key code="39" output="á"/>
+            <key code="40" output="k"/>
+            <key code="41" output="é"/>
+            <key code="42" output="ű"/>
+            <key code="43" output=","/>
+            <key code="44" output="-"/>
+            <key code="45" action="19"/>
+            <key code="46" output="m"/>
+            <key code="47" output="."/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" action="5"/>
+            <key code="50" output="0"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="&#x001D;"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="&#x001C;"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="&#x001F;"/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="&#x001E;"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="1">
+            <key code="0" action="6"/>
+            <key code="1" action="22"/>
+            <key code="2" output="D"/>
+            <key code="3" output="F"/>
+            <key code="4" output="H"/>
+            <key code="5" output="G"/>
+            <key code="6" output="Y"/>
+            <key code="7" output="X"/>
+            <key code="8" action="14"/>
+            <key code="9" output="V"/>
+            <key code="10" output="§"/>
+            <key code="11" output="B"/>
+            <key code="12" output="Q"/>
+            <key code="13" output="W"/>
+            <key code="14" action="16"/>
+            <key code="15" action="20"/>
+            <key code="16" action="25"/>
+            <key code="17" action="24"/>
+            <key code="18" output="&#x0027;"/>
+            <key code="19" output="&#x0022;"/>
+            <key code="20" output="+"/>
+            <key code="21" output="!"/>
+            <key code="22" output="/"/>
+            <key code="23" output="%"/>
+            <key code="24" output="Ó"/>
+            <key code="25" output=")"/>
+            <key code="26" output="="/>
+            <key code="27" output="Ü"/>
+            <key code="28" output="("/>
+            <key code="29" output="Ö"/>
+            <key code="30" output="Ú"/>
+            <key code="31" action="7"/>
+            <key code="32" action="8"/>
+            <key code="33" output="Ő"/>
+            <key code="34" output="I"/>
+            <key code="35" output="P"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" action="12"/>
+            <key code="38" output="J"/>
+            <key code="39" output="Á"/>
+            <key code="40" output="K"/>
+            <key code="41" output="É"/>
+            <key code="42" output="Ű"/>
+            <key code="43" output="?"/>
+            <key code="44" output="_"/>
+            <key code="45" action="18"/>
+            <key code="46" output="M"/>
+            <key code="47" output=":"/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" action="5"/>
+            <key code="50" output="Í"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="*"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="+"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="="/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="/"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="2">
+            <key code="0" action="6"/>
+            <key code="1" action="22"/>
+            <key code="2" output="D"/>
+            <key code="3" output="F"/>
+            <key code="4" output="H"/>
+            <key code="5" output="G"/>
+            <key code="6" output="Y"/>
+            <key code="7" output="X"/>
+            <key code="8" action="14"/>
+            <key code="9" output="V"/>
+            <key code="10" output="0"/>
+            <key code="11" output="B"/>
+            <key code="12" output="Q"/>
+            <key code="13" output="W"/>
+            <key code="14" action="16"/>
+            <key code="15" action="20"/>
+            <key code="16" action="25"/>
+            <key code="17" action="24"/>
+            <key code="18" output="1"/>
+            <key code="19" output="2"/>
+            <key code="20" output="3"/>
+            <key code="21" output="4"/>
+            <key code="22" output="6"/>
+            <key code="23" output="5"/>
+            <key code="24" output="Ó"/>
+            <key code="25" output="9"/>
+            <key code="26" output="7"/>
+            <key code="27" output="Ü"/>
+            <key code="28" output="8"/>
+            <key code="29" output="Ö"/>
+            <key code="30" output="Ú"/>
+            <key code="31" action="7"/>
+            <key code="32" action="8"/>
+            <key code="33" output="Ő"/>
+            <key code="34" output="I"/>
+            <key code="35" output="P"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" action="12"/>
+            <key code="38" output="J"/>
+            <key code="39" output="Á"/>
+            <key code="40" output="K"/>
+            <key code="41" output="É"/>
+            <key code="42" output="Ű"/>
+            <key code="43" output=","/>
+            <key code="44" output="-"/>
+            <key code="45" action="18"/>
+            <key code="46" output="M"/>
+            <key code="47" output="."/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" action="5"/>
+            <key code="50" output="0"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="&#x001D;"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="&#x001C;"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="&#x001F;"/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="&#x001E;"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="3">
+            <key code="0" output="ą"/>
+            <key code="1" output="ß"/>
+            <key code="2" output="∂"/>
+            <key code="3" output="["/>
+            <key code="4" output="ķ"/>
+            <key code="5" output="]"/>
+            <key code="6" output="«"/>
+            <key code="7" output="#"/>
+            <key code="8" output="&#x0026;"/>
+            <key code="9" output="@"/>
+            <key code="10" output="¬"/>
+            <key code="11" output="{"/>
+            <key code="12" output="\"/>
+            <key code="13" output="|"/>
+            <key code="14" output="€"/>
+            <key code="15" output="¶"/>
+            <key code="16" output="ź"/>
+            <key code="17" output="†"/>
+            <key code="18" output="~"/>
+            <key code="19" output="™"/>
+            <key code="20" output="^"/>
+            <key code="21" output="$"/>
+            <key code="22" output="›"/>
+            <key code="23" output="‹"/>
+            <key code="24" output="≠"/>
+            <key code="25" output="]"/>
+            <key code="26" output="`"/>
+            <key code="27" output="\"/>
+            <key code="28" output="["/>
+            <key code="29" output="}"/>
+            <key code="30" output="~"/>
+            <key code="31" output="Ņ"/>
+            <key code="32" action="0"/>
+            <key code="33" output="¨"/>
+            <key code="34" action="1"/>
+            <key code="35" output="Ļ"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" output="•"/>
+            <key code="38" output="í"/>
+            <key code="39" output="^"/>
+            <key code="40" output="Ż"/>
+            <key code="41" output="$"/>
+            <key code="42" output="`"/>
+            <key code="43" output=";"/>
+            <key code="44" output="*"/>
+            <key code="45" output="}"/>
+            <key code="46" output="&#x003C;"/>
+            <key code="47" output="&#x003E;"/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" output=" "/>
+            <key code="50" output="|"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="&#x001D;"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="&#x001C;"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="&#x001F;"/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="&#x001E;"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="4">
+            <key code="0" output="Ą"/>
+            <key code="1" output="ż"/>
+            <key code="2" output="Ž"/>
+            <key code="3" output="ž"/>
+            <key code="4" output="Õ"/>
+            <key code="5" output="Ū"/>
+            <key code="6" output="&#x003C;"/>
+            <key code="7" output="&#x003E;"/>
+            <key code="8" output="©"/>
+            <key code="9" output="‚"/>
+            <key code="10" output="•"/>
+            <key code="11" output="’"/>
+            <key code="12" output="ļ"/>
+            <key code="13" output="Ł"/>
+            <key code="14" output="š"/>
+            <key code="15" output="®"/>
+            <key code="16" output="Ź"/>
+            <key code="17" output="ś"/>
+            <key code="18" output="ŕ"/>
+            <key code="19" output="Ř"/>
+            <key code="20" output="#"/>
+            <key code="21" output="$"/>
+            <key code="22" output="Ŗ"/>
+            <key code="23" output="ř"/>
+            <key code="24" output="Ī"/>
+            <key code="25" output="}"/>
+            <key code="26" output="ŗ"/>
+            <key code="27" output="ī"/>
+            <key code="28" output="™"/>
+            <key code="29" output="°"/>
+            <key code="30" output="ý"/>
+            <key code="31" output="Į"/>
+            <key code="32" output="†"/>
+            <key code="33" output="Ý"/>
+            <key code="34" output="ť"/>
+            <key code="35" output="ł"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" output="Ů"/>
+            <key code="38" output="Í"/>
+            <key code="39" action="4"/>
+            <key code="40" output="&#x0026;"/>
+            <key code="41" output="ō"/>
+            <key code="42" output="Ģ"/>
+            <key code="43" output="*"/>
+            <key code="44" output="—"/>
+            <key code="45" output="Ų"/>
+            <key code="46" output="ų"/>
+            <key code="47" output="÷"/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" output=" "/>
+            <key code="50" output="Ŕ"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="*"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="+"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="="/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="/"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="5">
+            <key code="0" output="Ā"/>
+            <key code="1" output="ĺ"/>
+            <key code="2" output="Č"/>
+            <key code="3" output="č"/>
+            <key code="4" output="ď"/>
+            <key code="5" output="Ď"/>
+            <key code="6" output="ů"/>
+            <key code="7" output="Ű"/>
+            <key code="8" output="ā"/>
+            <key code="9" output="◊"/>
+            <key code="10" output="0"/>
+            <key code="11" output="ű"/>
+            <key code="12" output="ő"/>
+            <key code="13" output="Š"/>
+            <key code="14" output="š"/>
+            <key code="15" output="Ś"/>
+            <key code="16" output="ņ"/>
+            <key code="17" output="ś"/>
+            <key code="18" output="Ń"/>
+            <key code="19" output="ň"/>
+            <key code="20" output="£"/>
+            <key code="21" output="Ę"/>
+            <key code="22" output="Ė"/>
+            <key code="23" output="į"/>
+            <key code="24" output="ě"/>
+            <key code="25" output="Ľ"/>
+            <key code="26" output="ė"/>
+            <key code="27" output="Ě"/>
+            <key code="28" output="•"/>
+            <key code="29" output="ľ"/>
+            <key code="30" output="‘"/>
+            <key code="31" output="ô"/>
+            <key code="32" output="Ť"/>
+            <key code="33" output="“"/>
+            <key code="34" output="ť"/>
+            <key code="35" output="õ"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" output="ē"/>
+            <key code="38" output="Ē"/>
+            <key code="39" output="Ä"/>
+            <key code="40" output="ū"/>
+            <key code="41" output="ä"/>
+            <key code="42" output="ģ"/>
+            <key code="43" output="≤"/>
+            <key code="44" output="÷"/>
+            <key code="45" output="Ų"/>
+            <key code="46" output="ų"/>
+            <key code="47" output="≥"/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" output=" "/>
+            <key code="50" output="`"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="&#x001D;"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="&#x001C;"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="&#x001F;"/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="&#x001E;"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="6">
+            <key code="0" output="Ć"/>
+            <key code="1" output="ß"/>
+            <key code="2" output="∂"/>
+            <key code="3" output="ń"/>
+            <key code="4" output="ķ"/>
+            <key code="5" output="©"/>
+            <key code="6" output="Ĺ"/>
+            <key code="7" output="Ň"/>
+            <key code="8" output="ć"/>
+            <key code="9" output="√"/>
+            <key code="10" output="*"/>
+            <key code="11" output="ļ"/>
+            <key code="12" output="Ō"/>
+            <key code="13" output="∑"/>
+            <key code="14" output="ę"/>
+            <key code="15" output="®"/>
+            <key code="16" output="ī"/>
+            <key code="17" output="†"/>
+            <key code="18" output="Ń"/>
+            <key code="19" output="™"/>
+            <key code="20" output="£"/>
+            <key code="21" output="$"/>
+            <key code="22" output="§"/>
+            <key code="23" output="į"/>
+            <key code="24" output="≠"/>
+            <key code="25" output="Ľ"/>
+            <key code="26" output="¶"/>
+            <key code="27" output="–"/>
+            <key code="28" output="•"/>
+            <key code="29" output="ľ"/>
+            <key code="30" output="‘"/>
+            <key code="31" output="Ņ"/>
+            <key code="32" output="¨"/>
+            <key code="33" output="“"/>
+            <key code="34" output="^"/>
+            <key code="35" output="Ļ"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" output="¬"/>
+            <key code="38" output="∆"/>
+            <key code="39" output="Ä"/>
+            <key code="40" output="Ż"/>
+            <key code="41" output="ä"/>
+            <key code="42" output="«"/>
+            <key code="43" output=";"/>
+            <key code="44" output="–"/>
+            <key code="45" output="~"/>
+            <key code="46" output=";"/>
+            <key code="47" output="≥"/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" output=" "/>
+            <key code="50" output="`"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output=","/>
+            <key code="66" output="&#x001D;"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="&#x001C;"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="&#x001F;"/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="&#x001E;"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+        <keyMap index="7">
+            <key code="0" output="&#x0001;"/>
+            <key code="1" output="&#x0013;"/>
+            <key code="2" output="&#x0004;"/>
+            <key code="3" output="&#x0006;"/>
+            <key code="4" output="&#x0008;"/>
+            <key code="5" output="&#x0007;"/>
+            <key code="6" output="&#x001A;"/>
+            <key code="7" output="&#x0018;"/>
+            <key code="8" output="&#x0003;"/>
+            <key code="9" output="&#x0016;"/>
+            <key code="10" output="0"/>
+            <key code="11" output="&#x0002;"/>
+            <key code="12" output="&#x0011;"/>
+            <key code="13" output="&#x0017;"/>
+            <key code="14" output="&#x0005;"/>
+            <key code="15" output="&#x0012;"/>
+            <key code="16" output="&#x0019;"/>
+            <key code="17" output="&#x0014;"/>
+            <key code="18" output="1"/>
+            <key code="19" output="2"/>
+            <key code="20" output="3"/>
+            <key code="21" output="4"/>
+            <key code="22" output="6"/>
+            <key code="23" output="5"/>
+            <key code="24" output="="/>
+            <key code="25" output="9"/>
+            <key code="26" output="7"/>
+            <key code="27" output="&#x001F;"/>
+            <key code="28" output="8"/>
+            <key code="29" output="0"/>
+            <key code="30" output="&#x001D;"/>
+            <key code="31" output="&#x000F;"/>
+            <key code="32" output="&#x0015;"/>
+            <key code="33" output="&#x001B;"/>
+            <key code="34" output="&#x0009;"/>
+            <key code="35" output="&#x0010;"/>
+            <key code="36" output="&#x000D;"/>
+            <key code="37" output="&#x000C;"/>
+            <key code="38" output="&#x000A;"/>
+            <key code="39" output="&#x0027;"/>
+            <key code="40" output="&#x000B;"/>
+            <key code="41" output=";"/>
+            <key code="42" output="&#x001C;"/>
+            <key code="43" output=","/>
+            <key code="44" output="/"/>
+            <key code="45" output="&#x000E;"/>
+            <key code="46" output="&#x000D;"/>
+            <key code="47" output="."/>
+            <key code="48" output="&#x0009;"/>
+            <key code="49" action="5"/>
+            <key code="50" output="`"/>
+            <key code="51" output="&#x0008;"/>
+            <key code="52" output="&#x0003;"/>
+            <key code="53" output="&#x001B;"/>
+            <key code="64" output="&#x0010;"/>
+            <key code="65" output="."/>
+            <key code="66" output="&#x001D;"/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
+            <key code="70" output="&#x001C;"/>
+            <key code="71" output="&#x001B;"/>
+            <key code="72" output="&#x001F;"/>
+            <key code="75" output="/"/>
+            <key code="76" output="&#x0003;"/>
+            <key code="77" output="&#x001E;"/>
+            <key code="78" output="-"/>
+            <key code="79" output="&#x0010;"/>
+            <key code="80" output="&#x0010;"/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
+            <key code="96" output="&#x0010;"/>
+            <key code="97" output="&#x0010;"/>
+            <key code="98" output="&#x0010;"/>
+            <key code="99" output="&#x0010;"/>
+            <key code="100" output="&#x0010;"/>
+            <key code="101" output="&#x0010;"/>
+            <key code="102" output="&#x0010;"/>
+            <key code="103" output="&#x0010;"/>
+            <key code="104" output="&#x0010;"/>
+            <key code="105" output="&#x0010;"/>
+            <key code="106" output="&#x0010;"/>
+            <key code="107" output="&#x0010;"/>
+            <key code="108" output="&#x0010;"/>
+            <key code="109" output="&#x0010;"/>
+            <key code="110" output="&#x0010;"/>
+            <key code="111" output="&#x0010;"/>
+            <key code="112" output="&#x0010;"/>
+            <key code="113" output="&#x0010;"/>
+            <key code="114" output="&#x0005;"/>
+            <key code="115" output="&#x0001;"/>
+            <key code="116" output="&#x000B;"/>
+            <key code="117" output="&#x007F;"/>
+            <key code="118" output="&#x0010;"/>
+            <key code="119" output="&#x0004;"/>
+            <key code="120" output="&#x0010;"/>
+            <key code="121" output="&#x000C;"/>
+            <key code="122" output="&#x0010;"/>
+            <key code="123" output="&#x001C;"/>
+            <key code="124" output="&#x001D;"/>
+            <key code="125" output="&#x001F;"/>
+            <key code="126" output="&#x001E;"/>
+        </keyMap>
+    </keyMapSet>
+    <actions>
+        <action id="0">
+            <when state="none" next="s1"/>
+        </action>
+        <action id="1">
+            <when state="none" next="s2"/>
+        </action>
+        <action id="2">
+            <when state="none" next="s3"/>
+        </action>
+        <action id="3">
+            <when state="none" next="s4"/>
+        </action>
+        <action id="4">
+            <when state="none" next="s5"/>
+        </action>
+        <action id="5">
+            <when state="none" output=" "/>
+            <when state="s1" output="¨"/>
+            <when state="s2" output="^"/>
+            <when state="s3" output="–"/>
+            <when state="s4" output="~"/>
+            <when state="s5" output="ˇ"/>
+        </action>
+        <action id="6">
+            <when state="none" output="A"/>
+            <when state="s1" output="Ä"/>
+        </action>
+        <action id="7">
+            <when state="none" output="O"/>
+            <when state="s1" output="Ö"/>
+            <when state="s2" output="Ô"/>
+            <when state="s4" output="Õ"/>
+        </action>
+        <action id="8">
+            <when state="none" output="U"/>
+            <when state="s1" output="Ü"/>
+        </action>
+        <action id="9">
+            <when state="none" output="a"/>
+            <when state="s1" output="ä"/>
+        </action>
+        <action id="10">
+            <when state="none" output="o"/>
+            <when state="s1" output="ö"/>
+            <when state="s2" output="ô"/>
+            <when state="s4" output="õ"/>
+        </action>
+        <action id="11">
+            <when state="none" output="u"/>
+            <when state="s1" output="ü"/>
+        </action>
+        <action id="12">
+            <when state="none" output="L"/>
+            <when state="s3" output="Ł"/>
+        </action>
+        <action id="13">
+            <when state="none" output="l"/>
+            <when state="s3" output="ł"/>
+        </action>
+        <action id="14">
+            <when state="none" output="C"/>
+            <when state="s5" output="Č"/>
+        </action>
+        <action id="15">
+            <when state="none" output="c"/>
+            <when state="s5" output="č"/>
+        </action>
+        <action id="16">
+            <when state="none" output="E"/>
+            <when state="s5" output="Ě"/>
+        </action>
+        <action id="17">
+            <when state="none" output="e"/>
+            <when state="s5" output="ě"/>
+        </action>
+        <action id="18">
+            <when state="none" output="N"/>
+            <when state="s5" output="Ň"/>
+        </action>
+        <action id="19">
+            <when state="none" output="n"/>
+            <when state="s5" output="ň"/>
+        </action>
+        <action id="20">
+            <when state="none" output="R"/>
+            <when state="s5" output="Ř"/>
+        </action>
+        <action id="21">
+            <when state="none" output="r"/>
+            <when state="s5" output="ř"/>
+        </action>
+        <action id="22">
+            <when state="none" output="S"/>
+            <when state="s5" output="Š"/>
+        </action>
+        <action id="23">
+            <when state="none" output="s"/>
+            <when state="s5" output="š"/>
+        </action>
+        <action id="24">
+            <when state="none" output="T"/>
+            <when state="s5" output="Ť"/>
+        </action>
+        <action id="25">
+            <when state="none" output="Z"/>
+            <when state="s5" output="Ž"/>
+        </action>
+        <action id="26">
+            <when state="none" output="z"/>
+            <when state="s5" output="ž"/>
+        </action>
+    </actions>
+    <terminators>
+        <when state="s1" output="¨"/>
+        <when state="s2" output="^"/>
+        <when state="s3" output="–"/>
+        <when state="s4" output="~"/>
+        <when state="s5" output="ˇ"/>
+    </terminators>
+</keyboard>

--- a/Hungarian_Win.keylayout
+++ b/Hungarian_Win.keylayout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
-<!--Last edited by Ukelele version 2.2.8 on 2015-07-25 at 22:53 (BST)-->
+<!--Last edited by Ukelele version 2.2.8 on 2015-07-26 at 00:47 (BST)-->
 <!---->
 <keyboard group="29" id="30763" name="HungarianWin" maxout="1">
     <layouts>
@@ -641,7 +641,7 @@
             <key code="35" output="õ"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="ē"/>
-            <key code="38" output="Ē"/>
+            <key code="38" output="Í"/>
             <key code="39" output="Ä"/>
             <key code="40" output="ū"/>
             <key code="41" output="$"/>

--- a/Hungarian_Win.keylayout
+++ b/Hungarian_Win.keylayout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
-<!--Last edited by Ukelele version 2.0.1 on 2010-09-23 at 18:59 (GMT+09:00)-->
+<!--Last edited by Ukelele version 2.2.8 on 2015-07-25 at 22:53 (BST)-->
 <!---->
 <keyboard group="29" id="30763" name="HungarianWin" maxout="1">
     <layouts>
@@ -93,7 +93,7 @@
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
-            <key code="50" output="0"/>
+            <key code="50" output="í"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -317,7 +317,7 @@
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
-            <key code="50" output="0"/>
+            <key code="50" output="Í"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -385,11 +385,11 @@
             <key code="3" output="["/>
             <key code="4" output="ķ"/>
             <key code="5" output="]"/>
-            <key code="6" output="«"/>
+            <key code="6" output="&#x003E;"/>
             <key code="7" output="#"/>
             <key code="8" output="&#x0026;"/>
             <key code="9" output="@"/>
-            <key code="10" output="¬"/>
+            <key code="10" output="`"/>
             <key code="11" output="{"/>
             <key code="12" output="\"/>
             <key code="13" output="|"/>
@@ -428,8 +428,8 @@
             <key code="46" output="&#x003C;"/>
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=" "/>
-            <key code="50" output="|"/>
+            <key code="49" output=" "/>
+            <key code="50" output="&#x003C;"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -540,7 +540,7 @@
             <key code="46" output="ų"/>
             <key code="47" output="÷"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=" "/>
+            <key code="49" output=" "/>
             <key code="50" output="Ŕ"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -606,33 +606,33 @@
             <key code="0" output="Ā"/>
             <key code="1" output="ĺ"/>
             <key code="2" output="Č"/>
-            <key code="3" output="č"/>
+            <key code="3" output="["/>
             <key code="4" output="ď"/>
-            <key code="5" output="Ď"/>
-            <key code="6" output="ů"/>
-            <key code="7" output="Ű"/>
-            <key code="8" output="ā"/>
-            <key code="9" output="◊"/>
-            <key code="10" output="0"/>
-            <key code="11" output="ű"/>
-            <key code="12" output="ő"/>
-            <key code="13" output="Š"/>
+            <key code="5" output="]"/>
+            <key code="6" output="&#x003E;"/>
+            <key code="7" output="#"/>
+            <key code="8" output="&#x0026;"/>
+            <key code="9" output="@"/>
+            <key code="10" output="`"/>
+            <key code="11" output="{"/>
+            <key code="12" output="\"/>
+            <key code="13" output="|"/>
             <key code="14" output="š"/>
             <key code="15" output="Ś"/>
             <key code="16" output="ņ"/>
             <key code="17" output="ś"/>
-            <key code="18" output="Ń"/>
-            <key code="19" output="ň"/>
-            <key code="20" output="£"/>
-            <key code="21" output="Ę"/>
-            <key code="22" output="Ė"/>
-            <key code="23" output="į"/>
+            <key code="18" output="~"/>
+            <key code="19" output="™"/>
+            <key code="20" output="^"/>
+            <key code="21" output="$"/>
+            <key code="22" output="›"/>
+            <key code="23" output="‹"/>
             <key code="24" output="ě"/>
-            <key code="25" output="Ľ"/>
-            <key code="26" output="ė"/>
+            <key code="25" output="]"/>
+            <key code="26" output="`"/>
             <key code="27" output="Ě"/>
-            <key code="28" output="•"/>
-            <key code="29" output="ľ"/>
+            <key code="28" output="["/>
+            <key code="29" output="}"/>
             <key code="30" output="‘"/>
             <key code="31" output="ô"/>
             <key code="32" output="Ť"/>
@@ -644,16 +644,16 @@
             <key code="38" output="Ē"/>
             <key code="39" output="Ä"/>
             <key code="40" output="ū"/>
-            <key code="41" output="ä"/>
+            <key code="41" output="$"/>
             <key code="42" output="ģ"/>
-            <key code="43" output="≤"/>
-            <key code="44" output="÷"/>
-            <key code="45" output="Ų"/>
-            <key code="46" output="ų"/>
-            <key code="47" output="≥"/>
+            <key code="43" output=";"/>
+            <key code="44" output="*"/>
+            <key code="45" output="}"/>
+            <key code="46" output="&#x003C;"/>
+            <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=" "/>
-            <key code="50" output="`"/>
+            <key code="49" output=" "/>
+            <key code="50" output="&#x003C;"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -764,7 +764,7 @@
             <key code="46" output=";"/>
             <key code="47" output="≥"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=" "/>
+            <key code="49" output=" "/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>

--- a/README.markdown
+++ b/README.markdown
@@ -9,10 +9,13 @@ This layout puts the most important (for programming) characters back to
 where they usually are on a PC keyboard (Windows, Linux, probably every
 single OS got it right, except Mac OSX for some reason).
 
-0 is now right left to 1 (rather than í, which moved to Alt+J)
-Alt is now the primary way to enter symbols eg:
-Alt-Q is now \ Alt-V is @ and so on.
-Alt-F and Alt-G are [ and ] respectively.
+- 0 is now right left to 1 (rather than í, which moved to Alt+J)
+- On international QUERTY layouts you can type í with the key located between
+  the left shift and the Z. You can also use that key along with the Z key
+  combined with Alt to type the "<" and ">" symbols like on hungarian keyboards.
+- Alt is now the primary way to enter symbols eg:
+  - Alt-Q is now \ Alt-V is @ and so on.
+  - Alt-F and Alt-G are [ and ] respectively.
 
 In general, everything should be where it belongs on a PC keyboard.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # About
 
-Copy the keylayout file into Library/Keyboard Layouts and you can then
+Copy the keylayout file into `/Library/Keyboard Layouts/` and you can then
 select the new layout from System Preferences > Language & Text > Input Sources
 
 # Layout


### PR DESCRIPTION
- Converted the config file from old-mac text format to the new (replaced CR with LF to make the config file more source control and diff friendly)
- Fix: Capslock-on didn't allow typing symbols the hungarian way (the same is true for the Alt+J combo that allows typing "í" on keyboards where the physical í key is missing).
- Fix: The "í" character can be typed with the key located between left shift and Y keys (when this key exists on the keyboard)
- Added the standard hungarian way to type "<" and ">" symbols: Alt+í and Alt+y (but kept the other Alt+M and Alt+. too - these are required on keyboards where the physical í key is not present).
- The standard hungarian layout doesn't utilise Alt+0, I've bound the "`" symbol to this as a more comfortable alternative to the standard Alt+7.
